### PR TITLE
Add visit outcome as plain text

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,7 @@ import { Home } from './src/screens/Home';
 import { AddDoctorModal } from './src/screens/AddDoctorModal';
 import { Drugs } from './src/screens/Drugs';
 import { AddDrugModal } from './src/screens/AddDrugModal';
+import { AddVisitModal } from './src/screens/AddVisitModal';
 
 
 const Stack = createNativeStackNavigator<StackParamList>();
@@ -51,6 +52,7 @@ const App = () => {
         <Stack.Group screenOptions={{ presentation: 'modal' }}>
         <Stack.Screen name="AggiungiMedico" component={AddDoctorModal} />
         <Stack.Screen name="AggiungiFarmaco" component={AddDrugModal} />
+        <Stack.Screen name="AggiungiVisita" component={AddVisitModal} />
         </Stack.Group>
       </Stack.Navigator>
     </NavigationContainer>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -376,6 +376,8 @@ PODS:
     - React-jsi (= 0.70.6)
     - React-logger (= 0.70.6)
     - React-perflogger (= 0.70.6)
+  - RNDateTimePicker (6.7.3):
+    - React-Core
   - RNScreens (3.19.0):
     - React-Core
     - React-RCTImage
@@ -447,6 +449,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -540,6 +543,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNDateTimePicker:
+    :path: "../node_modules/@react-native-community/datetimepicker"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   RNSVG:
@@ -596,6 +601,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: c75ceef7aa60a33b2d5731ebe5800ddde40cefc4
   React-runtimeexecutor: 15437b576139df27635400de0599d9844f1ab817
   ReactCommon: 349be31adeecffc7986a0de875d7fb0dcf4e251c
+  RNDateTimePicker: 00247f26c34683c80be94207f488f6f13448586e
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSVG: c1e76b81c76cdcd34b4e1188852892dc280eb902
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "Gestionale",
       "version": "0.0.1",
       "dependencies": {
+        "@react-native-community/datetimepicker": "^6.7.3",
         "@react-navigation/native": "^6.1.2",
         "@react-navigation/native-stack": "^6.9.8",
         "react": "18.1.0",
@@ -4042,6 +4043,14 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-6.7.3.tgz",
+      "integrity": "sha512-fXWbEdHMLW/e8cts3snEsbOTbnFXfUHeO2pkiDFX3fWpFoDtUrRWvn50xbY13IJUUKHDhoJ+mj24nMRVIXfX1A==",
+      "dependencies": {
+        "invariant": "^2.2.4"
       }
     },
     "node_modules/@react-native-community/eslint-config": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
+    "@react-native-community/datetimepicker": "^6.7.3",
     "@react-navigation/native": "^6.1.2",
     "@react-navigation/native-stack": "^6.9.8",
     "react": "18.1.0",

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,0 +1,126 @@
+import React, {useRef, useState } from 'react';
+import {
+  FlatList,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  Modal,
+  View,
+} from 'react-native';
+import { Colors } from '../styles/colors';
+
+interface Props {
+  label: string;
+  data: Array<{ label: string; value: string }>;
+  onSelect: (item: { label: string; value: number }) => void;
+}
+
+const Dropdown = ({ label, data, onSelect } : Props) => {
+  const DropdownButton = useRef();
+  const [visible, setVisible] = useState(false);
+  const [selected, setSelected] = useState(undefined);
+  const [dropdownTop, setDropdownTop] = useState(0);
+
+  const toggleDropdown = (): void => {
+    visible ? setVisible(false) : openDropdown();
+  };
+
+  const openDropdown = () => {
+    DropdownButton.current.measure((_fx, _fy, _w, h, _px, py) => {
+      setDropdownTop(py + h);
+    });
+    setVisible(true);
+  };
+
+  const onItemPress = (item): void => {
+    setSelected(item);
+    onSelect(item);
+    setVisible(false);
+  };
+
+  const renderItem = ({ item }) => (
+    <TouchableOpacity style={styles.item} onPress={() => onItemPress(item)}>
+      <Text style={{color: Colors.white}}>{item.label}</Text>
+    </TouchableOpacity>
+  );
+
+  const renderDropdown = () => {
+    return (
+      <Modal visible={visible} transparent animationType="none">
+        <TouchableOpacity
+          style={styles.overlay}
+          onPress={() => setVisible(false)}
+        >
+          <View style={[styles.dropdown, { top: dropdownTop }]}>
+            <FlatList
+              data={data}
+              renderItem={renderItem}
+              keyExtractor={(item, index) => index.toString()}
+            />
+          </View>
+        </TouchableOpacity>
+      </Modal>
+    );
+  };
+
+  return (
+    <TouchableOpacity
+      ref={DropdownButton}
+      style={styles.button}
+      onPress={toggleDropdown}
+    >
+      {renderDropdown()}
+      <Text style={styles.buttonText}>
+        {(selected && selected.label) || label}
+      </Text>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    flexDirection: 'row',
+    // alignItems: 'center',
+    borderColor: Colors.green,
+    borderWidth: 1,
+    borderRadius: 10,
+    height: 50,
+    zIndex: 1,
+  },
+  buttonText: {
+    flex: 1,
+    padding: 10,
+    textAlign: 'center',
+  },
+  icon: {
+    marginRight: 10,
+  },
+  dropdown: {
+    // position: 'absolute',
+    // backgroundColor: Colors.green_ligth,
+    padding: 10,
+    borderRadius: 10,
+    // width: '100%',
+    // margin: 10,
+    // shadowColor: Colors.green_bright,
+    // shadowRadius: 4,
+    // shadowOffset: { height: 10, width: 0 },
+    // shadowOpacity: 0.7,
+  },
+  overlay: {
+    width: '100%',
+    height: '100%',
+    borderRadius: 10,
+  },
+
+  item: {
+    padding: 10,
+    borderBottomWidth: 1,
+    backgroundColor: Colors.green_ligth,
+    marginTop: 2,
+    marginBottom: 2,
+    borderRadius: 10,
+  },
+});
+
+export default Dropdown;

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { Colors } from '../styles/colors';
 
-interface Item {
+export interface Item {
     label: string; 
     value: number 
 }

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -9,16 +9,21 @@ import {
 } from 'react-native';
 import { Colors } from '../styles/colors';
 
+interface Item {
+    label: string; 
+    value: number 
+}
+
 interface Props {
   label: string;
-  data: Array<{ label: string; value: string }>;
-  onSelect: (item: { label: string; value: number }) => void;
+  data: Array<Item>;
+  onSelect: (item: Item) => void;
 }
 
 const Dropdown = ({ label, data, onSelect } : Props) => {
   const DropdownButton = useRef();
   const [visible, setVisible] = useState(false);
-  const [selected, setSelected] = useState(undefined);
+  const [selected, setSelected] = useState({} as Item);
   const [dropdownTop, setDropdownTop] = useState(0);
 
   const toggleDropdown = (): void => {
@@ -32,15 +37,15 @@ const Dropdown = ({ label, data, onSelect } : Props) => {
     setVisible(true);
   };
 
-  const onItemPress = (item): void => {
+  const onItemPress = (item : Item): void => {
     setSelected(item);
     onSelect(item);
     setVisible(false);
   };
 
-  const renderItem = ({ item }) => (
-    <TouchableOpacity style={styles.item} onPress={() => onItemPress(item)}>
-      <Text style={{color: Colors.white}}>{item.label}</Text>
+  const renderItem = (props : { item : Item}) => (
+    <TouchableOpacity style={styles.item} onPress={() => onItemPress(props.item)}>
+      <Text style={{color: Colors.white}}>{props.item.label}</Text>
     </TouchableOpacity>
   );
 

--- a/src/components/DrugItem.tsx
+++ b/src/components/DrugItem.tsx
@@ -2,6 +2,7 @@ import { Text, View } from 'react-native';
 
 import { styles } from '../styles/styles';
 import { Drug } from '../models/drug';
+import React from 'react';
 
 export const DrugItem = (props: { drug: Drug }) => {
 

--- a/src/components/doctor.tsx
+++ b/src/components/doctor.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Text, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 

--- a/src/components/doctorsHeader.tsx
+++ b/src/components/doctorsHeader.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { useNavigation } from '@react-navigation/native';
 import {Text, TouchableOpacity, View} from 'react-native';
 import { AddDoctorPropsNavigation } from '../routes/types';

--- a/src/components/outcome.tsx
+++ b/src/components/outcome.tsx
@@ -3,6 +3,7 @@ import { styles } from '../styles/styles';
 import { Outcome } from '../models/outcome';
 import { Colors } from '../styles/colors';
 import { SvgUri } from 'react-native-svg';
+import React from 'react';
 
 const productInfoType = (info: number) => {
     switch (info) {

--- a/src/components/outcomeHeader.tsx
+++ b/src/components/outcomeHeader.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {Text, View} from 'react-native';
 import { styles } from '../styles/styles';
 

--- a/src/components/visit.tsx
+++ b/src/components/visit.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
@@ -9,10 +11,6 @@ import { createDb } from '../models/db';
 import { getOutcomesByVisitId } from '../services/outcome';
 import { Outcome } from '../models/outcome';
 import { OutcomeMiniItem } from './outcome';
-
-
-
-
 
 export const VisitItem = (props: { visit: Visit }) => {
 

--- a/src/components/visit.tsx
+++ b/src/components/visit.tsx
@@ -11,6 +11,7 @@ import { createDb } from '../models/db';
 import { getOutcomesByVisitId } from '../services/outcome';
 import { Outcome } from '../models/outcome';
 import { OutcomeMiniItem } from './outcome';
+import { Colors } from '../styles/colors';
 
 export const VisitItem = (props: { visit: Visit }) => {
 
@@ -60,7 +61,8 @@ export const VisitItem = (props: { visit: Visit }) => {
 
     return (
         <TouchableOpacity style={styles.visitItem} onPress={navigateToVisita}>
-            <Text style={styles.visitDate}>{(new Date(Date.parse(props.visit.date))).toLocaleDateString()}</Text>
+            <Text style={styles.visitDate}>{(props.visit.date).toLocaleDateString()}</Text>
+            <Text style={{margin: 5, fontStyle: 'italic', color: Colors.black}}>{props.visit.note}</Text>
             {renderVisitItem(props.visit.outcome)}
         </TouchableOpacity>
     );

--- a/src/components/visitsHeader.tsx
+++ b/src/components/visitsHeader.tsx
@@ -1,10 +1,20 @@
-import {Text, View} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+import {Text, TouchableOpacity, View} from 'react-native';
+import { AddVisitPropsNavigation } from '../routes/types';
+import { Colors } from '../styles/colors';
 import { styles } from '../styles/styles';
 
 export const VisitsHeader= () => {
+
+    const navigation = useNavigation<AddVisitPropsNavigation>();
+
     return (
-        <View style={styles.listHeader}>
+        <View style={{...styles.listHeader, flexDirection: 'row', justifyContent: 'space-between'}}>
             <Text style={styles.listHeaderText}>APPUNTAMENTI</Text>
+            <TouchableOpacity style={{borderRadius: 20, borderWidth: 2, borderColor: Colors.white}} onPress={()=>navigation.navigate('AggiungiVisita')}>
+                <Text style={{color: Colors.white, fontWeight: 'bold', padding: 5}}> + </Text>
+            </TouchableOpacity>
         </View>
     );
 }

--- a/src/components/visitsHeader.tsx
+++ b/src/components/visitsHeader.tsx
@@ -5,14 +5,14 @@ import { AddVisitPropsNavigation } from '../routes/types';
 import { Colors } from '../styles/colors';
 import { styles } from '../styles/styles';
 
-export const VisitsHeader= () => {
+export const VisitsHeader= (props:{doctor: number, agent: number}) => {
 
     const navigation = useNavigation<AddVisitPropsNavigation>();
 
     return (
         <View style={{...styles.listHeader, flexDirection: 'row', justifyContent: 'space-between'}}>
             <Text style={styles.listHeaderText}>APPUNTAMENTI</Text>
-            <TouchableOpacity style={{borderRadius: 20, borderWidth: 2, borderColor: Colors.white}} onPress={()=>navigation.navigate('AggiungiVisita')}>
+            <TouchableOpacity style={{borderRadius: 20, borderWidth: 2, borderColor: Colors.white}} onPress={()=>navigation.navigate('AggiungiVisita', {doctorId: props.doctor, agentId: props.agent})}>
                 <Text style={{color: Colors.white, fontWeight: 'bold', padding: 5}}> + </Text>
             </TouchableOpacity>
         </View>

--- a/src/models/db.ts
+++ b/src/models/db.ts
@@ -44,15 +44,16 @@ let createVisitTable = `CREATE TABLE IF NOT EXISTS visit (
     doctor_id integer NOT NULL,
     agent_id integer NOT NULL,
     date datetime NOT NULL,
-    outcome integer NOT NULL
+    outcome integer NOT NULL,
+    note text
 );`;
 
-let seedVisitTable = `INSERT INTO visit (doctor_id, agent_id, date, outcome)
+let seedVisitTable = `INSERT INTO visit (doctor_id, agent_id, date, outcome, note)
 VALUES
-( 1, 0, '2023-01-01 12:00:00', -1),
-( 1, 0, '2023-01-02 12:00:00', 1 ),
-( 1, 0, '2023-01-03 12:00:00', 0 ),
-( 1, 0, '2023-01-04 12:00:00', 1)
+( 1, 0, '2023-01-01 12:00:00', -1, 'Non mi ha voluto ricevere'),
+( 1, 0, '2023-01-02 12:00:00', 1, 'Depliant Aspirina 100, Campione Brufen' ),
+( 1, 0, '2023-01-03 12:00:00', 0, 'Era fuori studio' ),
+( 1, 0, '2023-01-04 12:00:00', 1, 'Depliant Aspirina e Tachipirina')
 ;`;
 
 let dropProductTable = 'DROP TABLE IF EXISTS product;';

--- a/src/models/outcome.ts
+++ b/src/models/outcome.ts
@@ -7,3 +7,11 @@ export interface Outcome {
     product_info_type: number,
     note: string
   }
+
+export enum OutcomeType {
+  MATERIALE = 1,
+  RITORNARE = 0,
+  NEGATIVO = -1
+}
+
+export const OutcomeTypeArray = Object.keys(OutcomeType).filter(key => !isNaN(Number(key))).map(key => ({label:  OutcomeType[Number(key)], value: Number(key)}))

--- a/src/models/visit.ts
+++ b/src/models/visit.ts
@@ -2,6 +2,7 @@ export interface Visit {
     id: number,
     doctor_id: number,
     agent_id: number,
-    date: string,
-    outcome: number
+    date: Date,
+    outcome: number,
+    note: string
   }

--- a/src/routes/types.ts
+++ b/src/routes/types.ts
@@ -6,7 +6,8 @@ export type StackParamList = {
     Medico: { doctorId: number },
     Visita: { visitId: number },
     AggiungiMedico: undefined,
-    AggiungiFarmaco: undefined
+    AggiungiFarmaco: undefined,
+    AggiungiVisita: undefined
 };
 
 export type DoctorProps = NativeStackScreenProps<StackParamList, 'Medico'>;
@@ -19,3 +20,5 @@ export type DrugsProps = NativeStackScreenProps<StackParamList, 'Farmaci'>;
 export type DrugsPropsNavigation = DrugsProps['navigation'];
 export type AddDrugProps = NativeStackScreenProps<StackParamList, 'AggiungiFarmaco'>;
 export type AddDrugPropsNavigation = AddDrugProps['navigation'];
+export type AddVisitProps = NativeStackScreenProps<StackParamList, 'AggiungiVisita'>;
+export type AddVisitPropsNavigation = AddVisitProps['navigation'];

--- a/src/routes/types.ts
+++ b/src/routes/types.ts
@@ -7,7 +7,7 @@ export type StackParamList = {
     Visita: { visitId: number },
     AggiungiMedico: undefined,
     AggiungiFarmaco: undefined,
-    AggiungiVisita: undefined
+    AggiungiVisita: { doctorId: number, agentId: number }
 };
 
 export type DoctorProps = NativeStackScreenProps<StackParamList, 'Medico'>;

--- a/src/screens/AddVisitModal.tsx
+++ b/src/screens/AddVisitModal.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useCallback, useEffect } from "react";
 import { useState } from "react";
-import { FlatList, Modal, Text, TextInput, TouchableOpacity, View } from "react-native";
+import { FlatList, Modal, Text, TextInput, TouchableOpacity, unstable_batchedUpdates, View } from "react-native";
 import { createDb } from "../models/db";
 import DateTimePicker from '@react-native-community/datetimepicker';
 
@@ -9,17 +9,25 @@ import { AddVisitProps } from "../routes/types";
 import { styles } from "../styles/styles";
 import Dropdown from "../components/Dropdown";
 import { OutcomeTypeArray } from "../models/outcome";
+import { putVisit } from "../services/visit";
 
 export const AddVisitModal = ({ route, navigation }: AddVisitProps) => {
 
     const [visit, updVisit] = useState<Visit>({} as Visit);
-    const [curDate, updCurDate] = useState<Date>(new Date());
-    const [note, updNote] = useState('');
 
-    const [selected, setSelected] = useState({label:'One', value:1});
+    const loadDataCallback = useCallback(async () => {
+        updVisit({...visit, doctor_id : route.params.doctorId, agent_id : route.params.agentId});
+    }, []);
 
+
+    useEffect(() => {
+        loadDataCallback();
+    }, [loadDataCallback]);
 
     const putMyVisit = async (v: Visit) => {
+        console.log(v)
+        const db = await createDb();
+        await putVisit(db, v);
         navigation.goBack();
     }
 
@@ -28,16 +36,16 @@ export const AddVisitModal = ({ route, navigation }: AddVisitProps) => {
             <View>
                 <Text style={styles.textInputLabel}>DATA</Text>
                 <View style={{ ...styles.textInput, alignItems: 'flex-start' }}>
-                    <DateTimePicker testID="dateTimePicker" value={curDate} mode={'date'} is24Hour={true} onChange={(event, myDate) => { myDate && updCurDate(myDate) }} />
+                    <DateTimePicker testID="dateTimePicker" value={visit.date || new Date()} mode={'date'} is24Hour={true} onChange={(event, myDate) => { myDate && updVisit({...visit, date: myDate}) }} />
                 </View>
             </View>
             <View>
                 <Text style={styles.textInputLabel}>ESITO</Text>
-                <Dropdown data={OutcomeTypeArray} onSelect={setSelected} label={"SELEZIONA >"}/>
+                <Dropdown data={OutcomeTypeArray} onSelect={selected => updVisit({...visit, outcome: selected.value})} label={"SELEZIONA >"}/>
             </View>
             <View>
                 <Text style={styles.textInputLabel}>NOTE</Text>
-                <TextInput style={{...styles.textInput, height: 100}} multiline={true} onChangeText={(myNote) => updNote(myNote)} placeholder="Lasciato campione Aspirina1000" value={note} />
+                <TextInput style={{...styles.textInput, height: 100}} multiline={true} onChangeText={(myNote) => updVisit({...visit, note: myNote})} placeholder="Lasciato campione Aspirina1000" value={visit.note} />
             </View>
             <TouchableOpacity onPress={() => putMyVisit(visit)} style={styles.formButton}>
                 <Text style={styles.formButtonLabel}>AGGIUNGI</Text>

--- a/src/screens/AddVisitModal.tsx
+++ b/src/screens/AddVisitModal.tsx
@@ -1,33 +1,45 @@
 import React from "react";
 import { useState } from "react";
-import { Text, TextInput, TouchableOpacity, View } from "react-native";
+import { FlatList, Modal, Text, TextInput, TouchableOpacity, View } from "react-native";
 import { createDb } from "../models/db";
-import { Drug } from "../models/drug";
-import { AddDrugProps } from "../routes/types";
-import { putDrug } from "../services/drug";
+import DateTimePicker from '@react-native-community/datetimepicker';
+
+import { Visit } from "../models/visit";
+import { AddVisitProps } from "../routes/types";
 import { styles } from "../styles/styles";
+import Dropdown from "../components/Dropdown";
+import { OutcomeTypeArray } from "../models/outcome";
 
-export const AddVisitModal = ({ route, navigation }: AddDrugProps) => {
+export const AddVisitModal = ({ route, navigation }: AddVisitProps) => {
 
-    const [drug, updDrug] = useState<Drug>({} as Drug);
-    const putMyDrug = async (d: Drug) => {
-        console.log(d)
-        const db = await createDb();
-        await putDrug(db, d);
+    const [visit, updVisit] = useState<Visit>({} as Visit);
+    const [curDate, updCurDate] = useState<Date>(new Date());
+    const [note, updNote] = useState('');
+
+    const [selected, setSelected] = useState({label:'One', value:1});
+
+
+    const putMyVisit = async (v: Visit) => {
         navigation.goBack();
     }
 
     return (
         <View style={{ flex: 1, margin: 10 }}>
             <View>
-                <Text style={styles.textInputLabel}>NOME</Text>
-                <TextInput style={styles.textInput} onChangeText={(myName) => {updDrug({...drug, name: myName}) }} placeholder="Aspirina1000" value={drug.name} />
+                <Text style={styles.textInputLabel}>DATA</Text>
+                <View style={{ ...styles.textInput, alignItems: 'flex-start' }}>
+                    <DateTimePicker testID="dateTimePicker" value={curDate} mode={'date'} is24Hour={true} onChange={(event, myDate) => { myDate && updCurDate(myDate) }} />
+                </View>
             </View>
             <View>
-                <Text style={styles.textInputLabel}>DESCRIZIONE</Text>
-                <TextInput style={styles.textInput} onChangeText={(myDecsription) => {updDrug({...drug, description: myDecsription}) }} placeholder="Anti-infiammatorio" value={drug.description} />
+                <Text style={styles.textInputLabel}>ESITO</Text>
+                <Dropdown data={OutcomeTypeArray} onSelect={setSelected} label={"SELEZIONA >"}/>
             </View>
-                       <TouchableOpacity onPress={() => putMyDrug(drug)}  style={styles.formButton}>
+            <View>
+                <Text style={styles.textInputLabel}>NOTE</Text>
+                <TextInput style={{...styles.textInput, height: 100}} multiline={true} onChangeText={(myNote) => updNote(myNote)} placeholder="Lasciato campione Aspirina1000" value={note} />
+            </View>
+            <TouchableOpacity onPress={() => putMyVisit(visit)} style={styles.formButton}>
                 <Text style={styles.formButtonLabel}>AGGIUNGI</Text>
             </TouchableOpacity>
         </View>

--- a/src/screens/AddVisitModal.tsx
+++ b/src/screens/AddVisitModal.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { useState } from "react";
+import { Text, TextInput, TouchableOpacity, View } from "react-native";
+import { createDb } from "../models/db";
+import { Drug } from "../models/drug";
+import { AddDrugProps } from "../routes/types";
+import { putDrug } from "../services/drug";
+import { styles } from "../styles/styles";
+
+export const AddVisitModal = ({ route, navigation }: AddDrugProps) => {
+
+    const [drug, updDrug] = useState<Drug>({} as Drug);
+    const putMyDrug = async (d: Drug) => {
+        console.log(d)
+        const db = await createDb();
+        await putDrug(db, d);
+        navigation.goBack();
+    }
+
+    return (
+        <View style={{ flex: 1, margin: 10 }}>
+            <View>
+                <Text style={styles.textInputLabel}>NOME</Text>
+                <TextInput style={styles.textInput} onChangeText={(myName) => {updDrug({...drug, name: myName}) }} placeholder="Aspirina1000" value={drug.name} />
+            </View>
+            <View>
+                <Text style={styles.textInputLabel}>DESCRIZIONE</Text>
+                <TextInput style={styles.textInput} onChangeText={(myDecsription) => {updDrug({...drug, description: myDecsription}) }} placeholder="Anti-infiammatorio" value={drug.description} />
+            </View>
+                       <TouchableOpacity onPress={() => putMyDrug(drug)}  style={styles.formButton}>
+                <Text style={styles.formButtonLabel}>AGGIUNGI</Text>
+            </TouchableOpacity>
+        </View>
+    );
+}

--- a/src/screens/doctor.tsx
+++ b/src/screens/doctor.tsx
@@ -29,6 +29,7 @@ export const DoctorScreen = ({ route, navigation }: DoctorProps) => {
 
 
     useEffect(() => {
+        console.log(visits);
         loadDataCallback();
     }, [loadDataCallback]);
 
@@ -49,7 +50,7 @@ export const DoctorScreen = ({ route, navigation }: DoctorProps) => {
                    
             </View>
 
-            <FlatList data={visits} renderItem={({ item }) => <VisitItem visit={item} />} ListHeaderComponent={() => <VisitsHeader />} />
+            <FlatList data={visits} renderItem={({ item }) => <VisitItem visit={item} />} ListHeaderComponent={() => <VisitsHeader doctor={doctor.id} agent={visits[0] && visits[0].agent_id} />} />
         </View>
     );
 }

--- a/src/screens/home.tsx
+++ b/src/screens/home.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import { Text, TouchableOpacity, View } from "react-native";
 import { Colors } from "../styles/colors";
 import { SvgUri } from 'react-native-svg';

--- a/src/services/visit.ts
+++ b/src/services/visit.ts
@@ -9,13 +9,25 @@ export const getVisitsByDoctorId = async (db: SQLiteDatabase, id: number): Promi
 
         results.forEach(result => {
             for (let index = 0; index < result.rows.length; index++) {
-                console.log(result.rows.item(index));
-                resultArray.push(result.rows.item(index));
+                const myItem = result.rows.item(index);
+                myItem.date = new Date(Date.parse(myItem.date));
+                resultArray.push(myItem);
             }
         });
+        console.log(resultArray)
         return resultArray;
     } catch (error) {
         console.error(error);
         throw Error('Failed to get visits !!!');
     }
 };
+
+export const putVisit = async (db: SQLiteDatabase, v: Visit) => {
+    const putQuery = `INSERT OR REPLACE INTO visit (doctor_id, agent_id, date, outcome, note)
+        VALUES
+        ( '${v.doctor_id}', '${v.agent_id}', '${v.date.toISOString()}', '${v.outcome}', '${v.note}')
+        ;`;
+    console.log(putQuery);
+
+    return db.executeSql(putQuery);
+  };


### PR DESCRIPTION
This PR proposes to add a visit and its outcome as plain text. 
Visits view in doctor screen still contains outcome as a list of products, maybe it should be refactored.
When a visit is added, a re-render of doctor screen should be fired on back navigation

https://user-images.githubusercontent.com/8901084/218690144-6a266dc7-165a-481d-968e-5f60efbf149d.mov


https://user-images.githubusercontent.com/8901084/218690348-c19bfdd5-fa56-41c7-bd0a-6e197a0a6513.mov

