### PR TITLE
Fix Color on labels on Home screen

### DIFF
--- a/src/screens/home.tsx
+++ b/src/screens/home.tsx
@@ -18,15 +18,15 @@ export const Home = () => {
             <View style={{ flexDirection: 'row' }}>
                 <TouchableOpacity style={{ width: '33.33%', alignItems: 'center' }} onPress={() => navDoctor.navigate('Medici')}>
                     <SvgUri width="50%" height="50%" uri='https://www.svgrepo.com/download/325813/doctor-female.svg' />
-                    <Text>MEDICI</Text>
+                    <Text style={{color: Colors.black}}>MEDICI</Text>
                 </TouchableOpacity>
                 <View style={{ width: '33.33%', alignItems: 'center' }}>
                     <SvgUri width="50%" height="50%" uri='https://www.svgrepo.com/download/325869/city-worker.svg' />
-                    <Text>PROFILO</Text>
+                    <Text style={{color: Colors.black}}>PROFILO</Text>
                 </View>
                 <TouchableOpacity style={{ width: '33.33%', alignItems: 'center' }} onPress={() => navDrugs.navigate('Farmaci')}>
                     <SvgUri width="50%" height="50%" uri='https://www.svgrepo.com/download/325975/medicines.svg' />
-                    <Text>FARMACI</Text>
+                    <Text style={{color: Colors.black}}>FARMACI</Text>
                 </TouchableOpacity>
             </View>
         </View>


### PR DESCRIPTION
On many devices Labels in home screen inherit white color of the main/parent view, this PR proposes to override their color with palette black

<img width="458" alt="Schermata 2023-02-25 alle 09 27 39" src="https://user-images.githubusercontent.com/8901084/221347250-47b10436-566d-49a8-a859-d498da65dab7.png">
